### PR TITLE
Configure merchant display settings option

### DIFF
--- a/Model/Carrier.php
+++ b/Model/Carrier.php
@@ -650,8 +650,8 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
             $deadline,
             ($deadline > 1 ? __('dias úteis') : __('dia útil'))
         );
-        
-        if ($deadlineMessage) {
+
+        if ($deadlineMessage && $this->getConfigData('show_home_delivery_info')) {
             $methodTitle .= ' - ' . __('Entrega domiciliar indisponível. Retirar na Agência.');
         }
 

--- a/etc/adminhtml/system/service_settings.xml
+++ b/etc/adminhtml/system/service_settings.xml
@@ -65,5 +65,11 @@
                 <field id="active">1</field>
             </depends>
         </field>
+        <field id="show_home_delivery_info" translate="label,comment" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+            <label>Show Home Delivery Information</label>
+            <comment>When enabled, displays a message when home delivery is not available and package must be picked up at an agency.</comment>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>carriers/sigep_web_carrier/show_home_delivery_info</config_path>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -45,6 +45,7 @@
                 <label_format>ET</label_format>
                 <print_layout>LINEAR_100_150</print_layout>
                 <allowed_status>processing</allowed_status>
+                <show_home_delivery_info>1</show_home_delivery_info>
             </sigep_web_carrier>
         </carriers>
         <sigep>


### PR DESCRIPTION
Implementa uma nova configuração que permite ao lojista decidir se deseja ou não exibir a mensagem informando quando a entrega domiciliar não está disponível e o pacote deve ser retirado na agência dos Correios.

Mudanças:
- Adiciona campo "Show Home Delivery Information" nas configurações do admin
- Define valor padrão como ativado (1) no config.xml
- Modifica Carrier.php para verificar a configuração antes de exibir a mensagem